### PR TITLE
Bump compileSdkVersion for compatibility with Flutter 3.24.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Bumps compileSdkVersion for compatibility with Flutter 3.24.x.

The Flutter team pushed an undocumented change where they upgraded a bunch of AndroidX libs to latest. This breaks any plugin dependency that has a `compileSdkVersion` < 31 - as the AndroidX  deps require this as a minimum.

`pushy_flutter` was one of the packages we use impacted by this. Would appreciate your efforts here to get this bumped to, at a minimum, API 31. 