### PR TITLE
Issue 100 Resolved 

### DIFF
--- a/ios/Classes/PushyFlutter.swift
+++ b/ios/Classes/PushyFlutter.swift
@@ -327,7 +327,7 @@ public class PushyFlutter: NSObject, FlutterPlugin, FlutterStreamHandler {
         content.body = args[1]
                 
         // Set default sound
-        content.sound = .default()
+        content.sound = .default
         
         // Convert payload data to JSON
         if let data = args[2].data(using: .utf8) {


### PR DESCRIPTION
Replace content.sound = .default() with content.sound = .default in PushyFlutter.swift to resolve the Swift compiler error: Cannot call value of non-function type UNNotificationSound. This change ensures compatibility with the latest Swift and iOS APIs.