### PR TITLE
chore: bump compileSdk to 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ android {
         namespace 'me.pushy.sdk.flutter'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Bump `compileSdk` to 34. 

Most flutter things need to be at least 34 these days for gradle. Flutter defaults to 36 now - and play store requires 35 at a minimum - but 34 is a requirement for lots of other flutter packages now. 

See: 
https://github.com/flutter/flutter/blob/b45a73b1dc3e1b69e32ef6b6c1cec507c57a3960/packages/flutter_tools/lib/src/android/gradle_utils.dart#L52C7-L52C27
https://github.com/dart-lang/http/issues/1821#issuecomment-3309863735
https://issuetracker.google.com/issues/231712094?pli=1


Compiling latest `pushy_flutter` with AGP 8.13+ or 9.x yields:

```
Dependency 'androidx.window:window:1.2.0' requires libraries and applications that
   depend on it to compile against version 34 or later of the
   Android APIs.

   :pushy_flutter is currently compiled against android-31.

   Recommended action: Update this project to use a newer compileSdk
   of at least 34, for example 36.

   Note that updating a library or application's compileSdk (which
   allows newer APIs to be used) can be done separately from updating
   targetSdk (which opts the app in to new runtime behavior) and
   minSdk (which determines which devices the app can be installed
   on).


  ... Plenty more
```